### PR TITLE
fix table typos in Multiple Indexing section

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -2050,7 +2050,7 @@ single & n/a & row vector
 \code{a[is]} &
 multiple & n/a & matrix
 \\ \hline
-\code{a[is, js]} & single & single & real
+\code{a[i, j]} & single & single & real
 \\
 \code{a[i, js]} & single & multiple & row vector
 \\
@@ -2060,7 +2060,7 @@ multiple & n/a & matrix
 \end{tabular}
 \end{center}
 \caption{\small\it Special rules for reducing matrices based on
-  whether the argumnt is a single or multiple index.  Examples are for
+  whether the argument is a single or multiple index.  Examples are for
 a matrix \code{a}, with integer single indexes \code{i} and \code{j}
 and integer array multiple indexes \code{is} and \code{js}.  The same
 typing rules apply for all multiple indexes.}%


### PR DESCRIPTION
#### Submisison Checklist
- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below
#### Summary

fix table typos in Multiple Indexing section of reference manual
#### Intended Effect

fix typos in reference manual
#### How to Verify

manual inspection
#### Side Effects
#### Documentation
#### Reviewer Suggestions
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

indices 'i' and 'j' should be used to indicate single-valued indices;
"argumnt" => "argument";
